### PR TITLE
feat(html): collapse overflow sibling nodes behind ellipsis

### DIFF
--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -24,6 +24,7 @@ __all__ = ["MAX_LINE_WIDTH", "ANY", "RETURN", "YIELD", "NEVER", "REPLACE"]
 
 
 MAX_LINE_WIDTH = 88
+MAX_HTML_PARALLEL_CHILDREN = 5
 
 
 @dataclass(unsafe_hash=True)
@@ -573,8 +574,23 @@ class DictBasicWrapper(BasicWrapper):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("{")
         maker.addspan(" ... },", spancls="closed")
+        overflow_maker = HTMLTreeMaker("...")
+        has_overflow = False
+        visible_children = 0
         for k, v in self.__obj.items():
-            self.__get_html_subnode(k, v, is_change_view, status, color_scheme, maker)
+            target = maker
+            if (
+                not is_change_view
+                and not v.is_deleted()
+                and visible_children >= MAX_HTML_PARALLEL_CHILDREN
+            ):
+                target = overflow_maker
+                has_overflow = True
+            elif not is_change_view and not v.is_deleted():
+                visible_children += 1
+            self.__get_html_subnode(k, v, is_change_view, status, color_scheme, target)
+        if has_overflow:
+            maker.add(overflow_maker)
         maker.add("}", "t")
         return maker
 
@@ -810,8 +826,23 @@ class ListBasicWrapper(BasicWrapper):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("[")
         maker.addspan(" ... ],", spancls="closed")
+        overflow_maker = HTMLTreeMaker("...")
+        has_overflow = False
+        visible_children = 0
         for x in self.__obj:
-            self.__get_html_subnode(x, is_change_view, status, color_scheme, maker)
+            target = maker
+            if (
+                not is_change_view
+                and not x.is_deleted()
+                and visible_children >= MAX_HTML_PARALLEL_CHILDREN
+            ):
+                target = overflow_maker
+                has_overflow = True
+            elif not is_change_view and not x.is_deleted():
+                visible_children += 1
+            self.__get_html_subnode(x, is_change_view, status, color_scheme, target)
+        if has_overflow:
+            maker.add(overflow_maker)
         maker.add("]", "t")
         return maker
 

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -574,23 +574,21 @@ class DictBasicWrapper(BasicWrapper):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("{")
         maker.addspan(" ... },", spancls="closed")
-        overflow_maker = HTMLTreeMaker("...")
-        has_overflow = False
+        current_maker = maker
         visible_children = 0
         for k, v in self.__obj.items():
             target = maker
-            if (
-                not is_change_view
-                and not v.is_deleted()
-                and visible_children >= MAX_HTML_PARALLEL_CHILDREN
-            ):
-                target = overflow_maker
-                has_overflow = True
-            elif not is_change_view and not v.is_deleted():
+            if not is_change_view and not v.is_deleted():
+                if (
+                    visible_children > 0
+                    and visible_children % MAX_HTML_PARALLEL_CHILDREN == 0
+                ):
+                    overflow_maker = HTMLTreeMaker("...")
+                    current_maker.add(overflow_maker)
+                    current_maker = overflow_maker
+                target = current_maker
                 visible_children += 1
             self.__get_html_subnode(k, v, is_change_view, status, color_scheme, target)
-        if has_overflow:
-            maker.add(overflow_maker)
         maker.add("}", "t")
         return maker
 
@@ -826,23 +824,21 @@ class ListBasicWrapper(BasicWrapper):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("[")
         maker.addspan(" ... ],", spancls="closed")
-        overflow_maker = HTMLTreeMaker("...")
-        has_overflow = False
+        current_maker = maker
         visible_children = 0
         for x in self.__obj:
             target = maker
-            if (
-                not is_change_view
-                and not x.is_deleted()
-                and visible_children >= MAX_HTML_PARALLEL_CHILDREN
-            ):
-                target = overflow_maker
-                has_overflow = True
-            elif not is_change_view and not x.is_deleted():
+            if not is_change_view and not x.is_deleted():
+                if (
+                    visible_children > 0
+                    and visible_children % MAX_HTML_PARALLEL_CHILDREN == 0
+                ):
+                    overflow_maker = HTMLTreeMaker("...")
+                    current_maker.add(overflow_maker)
+                    current_maker = overflow_maker
+                target = current_maker
                 visible_children += 1
             self.__get_html_subnode(x, is_change_view, status, color_scheme, target)
-        if has_overflow:
-            maker.add(overflow_maker)
         maker.add("]", "t")
         return maker
 


### PR DESCRIPTION
### Motivation
- Avoid overly long/wide HTML tree expansions when a mapping or list has many parallel children by collapsing extras behind an expandable ellipsis.

### Description
- Add `MAX_HTML_PARALLEL_CHILDREN = 5` to control how many sibling children are shown inline in HTML trees.
- Update `DictBasicWrapper.get_html_node()` to keep the first `MAX_HTML_PARALLEL_CHILDREN` visible children and move remaining non-deleted siblings into an `HTMLTreeMaker("...")` overflow node that is appended and can be expanded to reveal the rest.
- Apply the same behavior to `ListBasicWrapper.get_html_node()` using a `visible_children` counter that only counts visible (non-deleted) items and preserves existing `is_change_view` handling.
- Preserve the existing flat/line-width fallback and change-view coloring/replace/delete semantics.

### Testing
- Ran `python -m compileall src/cfgtools/basic.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3824c448832ab35f019455f7702d)