### PR TITLE
Limit initial HTML child visibility to first five items

### DIFF
--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -567,10 +567,18 @@ class DictBasicWrapper(BasicWrapper):
         color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
+        visible_children_count = (
+            sum(not v.is_deleted() for v in self.__obj.values())
+            if not is_change_view
+            else len(self.__obj)
+        )
         lenflat, flat = self.repr_flat(
             is_change_view, partial(colorful_span, color_scheme)
         )
-        if lenflat <= self.get_max_line_width():
+        if (
+            lenflat <= self.get_max_line_width()
+            and visible_children_count <= MAX_HTML_PARALLEL_CHILDREN
+        ):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("{")
         maker.addspan(" ... },", spancls="closed")
@@ -817,10 +825,18 @@ class ListBasicWrapper(BasicWrapper):
         color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
+        visible_children_count = (
+            sum(not x.is_deleted() for x in self.__obj)
+            if not is_change_view
+            else len(self.__obj)
+        )
         lenflat, flat = self.repr_flat(
             is_change_view, partial(colorful_span, color_scheme)
         )
-        if lenflat <= self.get_max_line_width():
+        if (
+            lenflat <= self.get_max_line_width()
+            and visible_children_count <= MAX_HTML_PARALLEL_CHILDREN
+        ):
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("[")
         maker.addspan(" ... ],", spancls="closed")


### PR DESCRIPTION
### Motivation

- Ensure HTML rendering of mappings and lists collapses additional children when there are more than five visible items so the initial view only shows the first five children.
- Keep single-line (flat) rendering only when the line fits and the visible child count is within the parallel-child threshold to avoid unexpectedly exposing many items.

### Description

- Added a `visible_children_count` pre-check in `DictBasicWrapper.get_html_node` to count non-deleted children (or total when `is_change_view`), and require it to be `<= MAX_HTML_PARALLEL_CHILDREN` before using single-line rendering.
- Added the same `visible_children_count` pre-check in `ListBasicWrapper.get_html_node` so lists follow the same visibility rule.
- Kept existing overflow/grouping logic that creates `HTMLTreeMaker` overflow nodes and the `" ... },"` / `" ... ],"` closed spans so items after the first five remain hidden initially.

### Testing

- Ran `python -m compileall src/cfgtools/basic.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3ae2d18c832abd36cd9b059f2e35)