### PR TITLE
revert: rollback latest merged visibility change

### DIFF
--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -567,18 +567,10 @@ class DictBasicWrapper(BasicWrapper):
         color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
-        visible_children_count = (
-            sum(not v.is_deleted() for v in self.__obj.values())
-            if not is_change_view
-            else len(self.__obj)
-        )
         lenflat, flat = self.repr_flat(
             is_change_view, partial(colorful_span, color_scheme)
         )
-        if (
-            lenflat <= self.get_max_line_width()
-            and visible_children_count <= MAX_HTML_PARALLEL_CHILDREN
-        ):
+        if lenflat <= self.get_max_line_width():
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("{")
         maker.addspan(" ... },", spancls="closed")
@@ -825,18 +817,10 @@ class ListBasicWrapper(BasicWrapper):
         color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
-        visible_children_count = (
-            sum(not x.is_deleted() for x in self.__obj)
-            if not is_change_view
-            else len(self.__obj)
-        )
         lenflat, flat = self.repr_flat(
             is_change_view, partial(colorful_span, color_scheme)
         )
-        if (
-            lenflat <= self.get_max_line_width()
-            and visible_children_count <= MAX_HTML_PARALLEL_CHILDREN
-        ):
+        if lenflat <= self.get_max_line_width():
             return HTMLTreeMaker(flat)
         maker = HTMLTreeMaker("[")
         maker.addspan(" ... ],", spancls="closed")


### PR DESCRIPTION
### Motivation

- Roll back the recently merged change that altered HTML child-node visibility/pagination behavior so the renderer returns to the previous semantics. 
- Restore the prior behavior to avoid collapsing children prematurely based on a computed visible child count and rely on the prior line-length based shortcut.

### Description

- Reverted the merge and restored the previous implementation of `get_html_node` for both `DictBasicWrapper` and `ListBasicWrapper` in `src/cfgtools/basic.py`.
- Removed the `visible_children_count` calculation and the additional early-return condition that used `MAX_HTML_PARALLEL_CHILDREN`, leaving the original `lenflat`-based early return.
- Kept the existing overflow/ellipsis grouping logic that paginates visible children into overflow `HTMLTreeMaker` nodes during rendering.

### Testing

- No automated tests were run for this revert-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3bdd7a18832aa118723eb3bd329b)