### PR TITLE
feat: add `light` color scheme optimized for white backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ cfgtools.config({
 If user wants to check the changed items, run:
 ```py
 >>> f.view_change()
+>>> f.view_change("light")  # optimized for light/white backgrounds
 ```
 
 ## See Also

--- a/src/cfgtools/_typing.py
+++ b/src/cfgtools/_typing.py
@@ -25,5 +25,5 @@ DataObj = dict[BasicObj, "DataObj"] | list["DataObj"] | BasicObj | BasicWrapper
 ConfigFileFormat = Literal[
     "yaml", "yml", "pickle", "pkl", "json", "ini", "text", "txt", "bytes"
 ]
-ColorScheme = Literal["dark", "modern", "high-intensty"]
+ColorScheme = Literal["dark", "modern", "high-intensty", "light"]
 WrapperStatus = Literal["", "a", "d", "r"]

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -89,14 +89,14 @@ def colorful_span(
 
 def get_color_style(color_scheme: "ColorScheme", status: "WrapperStatus") -> str:
     """Return coloful css style."""
-    _, r, g = get_bg_colors(color_scheme)
+    text, r, g = get_bg_colors(color_scheme)
     match status:
         case "":
             return ""
         case "a" | "r":
-            return f"text-decoration:none;color:#cccccc;background-color:{g}"
+            return f"text-decoration:none;color:{text};background-color:{g}"
         case "d":
-            return f"text-decoration:none;color:#cccccc;background-color:{r}"
+            return f"text-decoration:none;color:{text};background-color:{r}"
         case _:
             raise ValueError(f"invalid status: {status!r}")
 
@@ -105,11 +105,13 @@ def get_bg_colors(color_scheme: "ColorScheme") -> tuple[str, str, str]:
     """Get background colors."""
     match color_scheme:
         case "dark":
-            return ["#505050", "#4d2f2f", "#2f4d2f"]
+            return ["#cccccc", "#4d2f2f", "#2f4d2f"]
         case "modern":
-            return ["#505050", "#701414", "#4e5d2d"]
+            return ["#cccccc", "#701414", "#4e5d2d"]
         case "high-intensty":
-            return ["#505050", "#701414", "#147014"]
+            return ["#cccccc", "#701414", "#147014"]
+        case "light":
+            return ["#1f2328", "#ffd8d3", "#d9f2d9"]
         case _:
             raise ValueError(f"invalid color scheme: {color_scheme!r}")
 


### PR DESCRIPTION
### Motivation
- Improve readability of HTML change-view output on white/bright backgrounds by providing a light-optimized color scheme and using per-scheme foreground colors.

### Description
- Added a new `light` option to the `ColorScheme` literal in `src/cfgtools/_typing.py` to expose the new scheme.
- Updated `get_bg_colors` in `src/cfgtools/basic.py` to return a tuple where the first element is the text color and added the `light` palette (`#1f2328` text with pale red/green backgrounds). 
- Changed `get_color_style` to use the per-scheme text color returned from `get_bg_colors` instead of a hardcoded `#cccccc` foreground so schemes can specify appropriate text colors. 
- Documented the new usage in `README.md` with an example call `f.view_change("light")` for white-background interfaces.

### Testing
- Ran `python -m compileall src` which completed successfully for the modified files. 
- Attempted a runtime import check with `PYTHONPATH=src python -c 'from cfgtools.basic import get_color_style; print(get_color_style("light","a"))'` but it failed due to missing environment dependency `lazyr`, so runtime execution was not fully verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def197c6ac832a95e6dbed382142ad)