### PR TITLE
Add `auto` color scheme to auto-switch HTML change view by system theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ cfgtools.config({
 ```
 If user wants to check the changed items, run:
 ```py
->>> f.view_change()
+>>> f.view_change()  # auto-switches between dark/light by system preference
 >>> f.view_change("light")  # optimized for light/white backgrounds
+>>> f.view_change("dark")  # optimized for dark backgrounds
 ```
 
 ## See Also

--- a/src/cfgtools/_typing.py
+++ b/src/cfgtools/_typing.py
@@ -25,5 +25,5 @@ DataObj = dict[BasicObj, "DataObj"] | list["DataObj"] | BasicObj | BasicWrapper
 ConfigFileFormat = Literal[
     "yaml", "yml", "pickle", "pkl", "json", "ini", "text", "txt", "bytes"
 ]
-ColorScheme = Literal["dark", "modern", "high-intensty", "light"]
+ColorScheme = Literal["auto", "dark", "modern", "high-intensty", "light"]
 WrapperStatus = Literal["", "a", "d", "r"]

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Self
 
 from htmlmaster import HTMLTreeMaker
 
-from .css import TREE_CSS_STYLE
+from .css import AUTO_CHANGE_VIEW_CSS_STYLE, TREE_CSS_STYLE
 
 if TYPE_CHECKING:
     from ._typing import BasicObj, ColorScheme, DataObj, UnwrappedDataObj, WrapperStatus
@@ -104,6 +104,12 @@ def get_color_style(color_scheme: "ColorScheme", status: "WrapperStatus") -> str
 def get_bg_colors(color_scheme: "ColorScheme") -> tuple[str, str, str]:
     """Get background colors."""
     match color_scheme:
+        case "auto":
+            return [
+                "var(--cfgtools-text)",
+                "var(--cfgtools-red)",
+                "var(--cfgtools-green)",
+            ]
         case "dark":
             return ["#cccccc", "#4d2f2f", "#2f4d2f"]
         case "modern":
@@ -207,7 +213,7 @@ class BasicWrapper:
         _, _, string = is_change_view, colorful_func, repr(self.__obj)
         return len(string), string
 
-    def view_change(self, color_scheme: "ColorScheme" = "dark") -> "ChangeView":
+    def view_change(self, color_scheme: "ColorScheme" = "auto") -> "ChangeView":
         """View the change of self since initialized."""
         _ = color_scheme
         return ChangeView(self.repr(0, True), self.to_html(True, color_scheme))
@@ -292,7 +298,7 @@ class BasicWrapper:
         raise TypeError(f"{self.__desc()} is not convertible to 'None'")
 
     def to_html(
-        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "dark"
+        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "auto"
     ) -> HTMLTreeMaker:
         """Return an HTMLTreeMaker object for representing self."""
         maker = self.get_html_node(is_change_view, color_scheme)
@@ -300,13 +306,15 @@ class BasicWrapper:
         main_maker = HTMLTreeMaker()
         main_maker.add(maker)
         main_maker.setrootstyle(TREE_CSS_STYLE)
+        if color_scheme == "auto":
+            main_maker.setrootstyle(AUTO_CHANGE_VIEW_CSS_STYLE)
         main_maker.setrootcls("cfgtools-tree")
         return main_maker
 
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "dark",
+        color_scheme: "ColorScheme" = "auto",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         """
@@ -565,7 +573,7 @@ class DictBasicWrapper(BasicWrapper):
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "dark",
+        color_scheme: "ColorScheme" = "auto",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         lenflat, flat = self.repr_flat(
@@ -802,7 +810,7 @@ class ListBasicWrapper(BasicWrapper):
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "dark",
+        color_scheme: "ColorScheme" = "auto",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         lenflat, flat = self.repr_flat(

--- a/src/cfgtools/css.py
+++ b/src/cfgtools/css.py
@@ -46,3 +46,19 @@ TREE_CSS_STYLE = """<style type="text/css">
 }}
 </style>
 """
+
+AUTO_CHANGE_VIEW_CSS_STYLE = """<style type="text/css">
+.cfgtools-tree {
+    --cfgtools-text: #cccccc;
+    --cfgtools-red: #4d2f2f;
+    --cfgtools-green: #2f4d2f;
+}
+@media (prefers-color-scheme: light) {
+    .cfgtools-tree {
+        --cfgtools-text: #1f2328;
+        --cfgtools-red: #ffd8d3;
+        --cfgtools-green: #d9f2d9;
+    }
+}
+</style>
+"""

--- a/src/cfgtools/iowrapper.py
+++ b/src/cfgtools/iowrapper.py
@@ -129,7 +129,7 @@ class ConfigIOWrapper(BasicWrapper, ConfigSaver):
         return f"cfgtools.config({s})"
 
     def to_html(
-        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "dark"
+        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "auto"
     ) -> HTMLTreeMaker:
         main_maker = super().to_html(is_change_view, color_scheme)
         main_maker.add("", licls="i")


### PR DESCRIPTION
### Motivation
- Provide an automatic UI mode that switches `light`/`dark` palettes for HTML change views according to the system `prefers-color-scheme` so users don't need to pick a scheme manually.
- Keep existing explicit schemes (`dark`, `light`, `modern`, `high-intensty`) while making the automatic behavior the default for change-view rendering.

### Description
- Added a new `auto` member to the `ColorScheme` typing and made `auto` the default for `view_change()` and `to_html()` call paths by changing their default `color_scheme` argument to `"auto"` in `BasicWrapper` and `ConfigIOWrapper`.
- Implemented `get_bg_colors()` handling for `"auto"` to return CSS variable names and added `AUTO_CHANGE_VIEW_CSS_STYLE` in `src/cfgtools/css.py` which defines those variables and a `@media (prefers-color-scheme: light)` rule to flip values for light-mode systems.
- When `color_scheme == "auto"` the HTML renderer injects the `AUTO_CHANGE_VIEW_CSS_STYLE` into the root style so rendered change-view HTML automatically adapts to the system theme.
- Updated README usage examples to mention the new default auto-switching behavior and adjusted relevant function signatures/usages in `src/cfgtools/_typing.py`, `src/cfgtools/basic.py`, and `src/cfgtools/iowrapper.py`.

### Testing
- Ran `python -m compileall src` which succeeded and confirmed the code compiles.
- Ran `black --check` which initially reported a reformat is needed, then ran `black` to reformat `src/cfgtools/basic.py` successfully.
- Attempted a runtime snippet with `PYTHONPATH=src` to inspect generated HTML, but import failed due to a missing optional dependency `lazyr` in the environment, so runtime verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def5919944832a8f47270e4f2e8d13)