### PR TITLE
Revert light/dark mode merge changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ cfgtools.config({
 ```
 If user wants to check the changed items, run:
 ```py
->>> f.view_change()  # auto-switches between dark/light by system preference
+>>> f.view_change()
 >>> f.view_change("light")  # optimized for light/white backgrounds
->>> f.view_change("dark")  # optimized for dark backgrounds
 ```
 
 ## See Also

--- a/src/cfgtools/_typing.py
+++ b/src/cfgtools/_typing.py
@@ -25,5 +25,5 @@ DataObj = dict[BasicObj, "DataObj"] | list["DataObj"] | BasicObj | BasicWrapper
 ConfigFileFormat = Literal[
     "yaml", "yml", "pickle", "pkl", "json", "ini", "text", "txt", "bytes"
 ]
-ColorScheme = Literal["auto", "dark", "modern", "high-intensty", "light"]
+ColorScheme = Literal["dark", "modern", "high-intensty", "light"]
 WrapperStatus = Literal["", "a", "d", "r"]

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Self
 
 from htmlmaster import HTMLTreeMaker
 
-from .css import AUTO_CHANGE_VIEW_CSS_STYLE, TREE_CSS_STYLE
+from .css import TREE_CSS_STYLE
 
 if TYPE_CHECKING:
     from ._typing import BasicObj, ColorScheme, DataObj, UnwrappedDataObj, WrapperStatus
@@ -104,12 +104,6 @@ def get_color_style(color_scheme: "ColorScheme", status: "WrapperStatus") -> str
 def get_bg_colors(color_scheme: "ColorScheme") -> tuple[str, str, str]:
     """Get background colors."""
     match color_scheme:
-        case "auto":
-            return [
-                "var(--cfgtools-text)",
-                "var(--cfgtools-red)",
-                "var(--cfgtools-green)",
-            ]
         case "dark":
             return ["#cccccc", "#4d2f2f", "#2f4d2f"]
         case "modern":
@@ -213,7 +207,7 @@ class BasicWrapper:
         _, _, string = is_change_view, colorful_func, repr(self.__obj)
         return len(string), string
 
-    def view_change(self, color_scheme: "ColorScheme" = "auto") -> "ChangeView":
+    def view_change(self, color_scheme: "ColorScheme" = "dark") -> "ChangeView":
         """View the change of self since initialized."""
         _ = color_scheme
         return ChangeView(self.repr(0, True), self.to_html(True, color_scheme))
@@ -298,7 +292,7 @@ class BasicWrapper:
         raise TypeError(f"{self.__desc()} is not convertible to 'None'")
 
     def to_html(
-        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "auto"
+        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "dark"
     ) -> HTMLTreeMaker:
         """Return an HTMLTreeMaker object for representing self."""
         maker = self.get_html_node(is_change_view, color_scheme)
@@ -306,15 +300,13 @@ class BasicWrapper:
         main_maker = HTMLTreeMaker()
         main_maker.add(maker)
         main_maker.setrootstyle(TREE_CSS_STYLE)
-        if color_scheme == "auto":
-            main_maker.setrootstyle(AUTO_CHANGE_VIEW_CSS_STYLE)
         main_maker.setrootcls("cfgtools-tree")
         return main_maker
 
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "auto",
+        color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         """
@@ -573,7 +565,7 @@ class DictBasicWrapper(BasicWrapper):
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "auto",
+        color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         lenflat, flat = self.repr_flat(
@@ -810,7 +802,7 @@ class ListBasicWrapper(BasicWrapper):
     def get_html_node(
         self,
         is_change_view: bool = False,
-        color_scheme: "ColorScheme" = "auto",
+        color_scheme: "ColorScheme" = "dark",
         status: "WrapperStatus" = "",
     ) -> HTMLTreeMaker:
         lenflat, flat = self.repr_flat(

--- a/src/cfgtools/css.py
+++ b/src/cfgtools/css.py
@@ -46,19 +46,3 @@ TREE_CSS_STYLE = """<style type="text/css">
 }}
 </style>
 """
-
-AUTO_CHANGE_VIEW_CSS_STYLE = """<style type="text/css">
-.cfgtools-tree {
-    --cfgtools-text: #cccccc;
-    --cfgtools-red: #4d2f2f;
-    --cfgtools-green: #2f4d2f;
-}
-@media (prefers-color-scheme: light) {
-    .cfgtools-tree {
-        --cfgtools-text: #1f2328;
-        --cfgtools-red: #ffd8d3;
-        --cfgtools-green: #d9f2d9;
-    }
-}
-</style>
-"""

--- a/src/cfgtools/iowrapper.py
+++ b/src/cfgtools/iowrapper.py
@@ -129,7 +129,7 @@ class ConfigIOWrapper(BasicWrapper, ConfigSaver):
         return f"cfgtools.config({s})"
 
     def to_html(
-        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "auto"
+        self, is_change_view: bool = False, color_scheme: "ColorScheme" = "dark"
     ) -> HTMLTreeMaker:
         main_maker = super().to_html(is_change_view, color_scheme)
         main_maker.add("", licls="i")


### PR DESCRIPTION
### Motivation
- Undo the recent light/dark mode switching changes that introduced an `auto` color scheme and additional CSS variables.
- Restore the previous, simpler behavior for HTML change views and color defaults to avoid the introduced styling complexity.

### Description
- Reverted README examples to the prior `view_change()` and `view_change("light")` usage and removed the `auto` example from documentation in `README.md`.
- Removed the `"auto"` variant from the `ColorScheme` literal in `src/cfgtools/_typing.py`.
- Removed the `AUTO_CHANGE_VIEW_CSS_STYLE` CSS constant and related CSS variable approach from `src/cfgtools/css.py`.
- Restored `basic`/`iowrapper` behavior in `src/cfgtools/basic.py` and `src/cfgtools/iowrapper.py` by removing the `auto` handling, dropping the extra CSS import, and setting the default `color_scheme` parameters back to `"dark"`.

### Testing
- Ran `pytest -q` which reported no tests were collected and exited with code 5.
- No other automated tests are present or were changed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def8d0680c832a8df8ff13dbea35fb)