### PR TITLE
Support `light` and `auto` color schemes for change view and add CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cfgtools.config({
 If user wants to check the changed items, run:
 ```py
 >>> f.view_change()
+>>> f.view_change("light")  # optimized for light/white backgrounds
+>>> f.view_change("auto")   # follow system theme (light/dark)
 ```
 
 ## See Also

--- a/src/cfgtools/_typing.py
+++ b/src/cfgtools/_typing.py
@@ -25,5 +25,5 @@ DataObj = dict[BasicObj, "DataObj"] | list["DataObj"] | BasicObj | BasicWrapper
 ConfigFileFormat = Literal[
     "yaml", "yml", "pickle", "pkl", "json", "ini", "text", "txt", "bytes"
 ]
-ColorScheme = Literal["dark", "modern", "high-intensty"]
+ColorScheme = Literal["dark", "modern", "high-intensty", "light", "auto"]
 WrapperStatus = Literal["", "a", "d", "r"]

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -89,14 +89,14 @@ def colorful_span(
 
 def get_color_style(color_scheme: "ColorScheme", status: "WrapperStatus") -> str:
     """Return coloful css style."""
-    _, r, g = get_bg_colors(color_scheme)
+    text, r, g = get_bg_colors(color_scheme)
     match status:
         case "":
             return ""
         case "a" | "r":
-            return f"text-decoration:none;color:#cccccc;background-color:{g}"
+            return f"text-decoration:none;color:{text};background-color:{g}"
         case "d":
-            return f"text-decoration:none;color:#cccccc;background-color:{r}"
+            return f"text-decoration:none;color:{text};background-color:{r}"
         case _:
             raise ValueError(f"invalid status: {status!r}")
 
@@ -105,11 +105,19 @@ def get_bg_colors(color_scheme: "ColorScheme") -> tuple[str, str, str]:
     """Get background colors."""
     match color_scheme:
         case "dark":
-            return ["#505050", "#4d2f2f", "#2f4d2f"]
+            return ["#cccccc", "#4d2f2f", "#2f4d2f"]
         case "modern":
-            return ["#505050", "#701414", "#4e5d2d"]
+            return ["#cccccc", "#701414", "#4e5d2d"]
         case "high-intensty":
-            return ["#505050", "#701414", "#147014"]
+            return ["#cccccc", "#701414", "#147014"]
+        case "light":
+            return ["#1f2328", "#ffd8d3", "#d9f2d9"]
+        case "auto":
+            return [
+                "var(--cfgtools-change-fg,#cccccc)",
+                "var(--cfgtools-change-del-bg,#4d2f2f)",
+                "var(--cfgtools-change-add-bg,#2f4d2f)",
+            ]
         case _:
             raise ValueError(f"invalid color scheme: {color_scheme!r}")
 

--- a/src/cfgtools/css.py
+++ b/src/cfgtools/css.py
@@ -9,6 +9,18 @@ NOTE: this module is private. All functions and objects are available in the mai
 __all__ = []
 
 TREE_CSS_STYLE = """<style type="text/css">
+.{0} {{
+    --cfgtools-change-fg: #cccccc;
+    --cfgtools-change-del-bg: #4d2f2f;
+    --cfgtools-change-add-bg: #2f4d2f;
+}}
+@media (prefers-color-scheme: light) {{
+    .{0} {{
+        --cfgtools-change-fg: #1f2328;
+        --cfgtools-change-del-bg: #ffd8d3;
+        --cfgtools-change-add-bg: #d9f2d9;
+    }}
+}}
 .{0} li.m {{
     display: block;
     position: relative;


### PR DESCRIPTION
### Motivation
- Provide readable change highlighting on light/white backgrounds and let the UI follow the system theme.
- Centralize color configuration so HTML output from `view_change()` can adapt between dark and light modes.

### Description
- Updated the `README.md` examples to show `f.view_change("light")` and `f.view_change("auto")` usage. 
- Extended the `ColorScheme` literal in `src/cfgtools/_typing.py` to include `"light"` and `"auto"`.
- Changed `get_color_style()` and `get_bg_colors()` in `src/cfgtools/basic.py` to use a returned text color and to add cases for the new `"light"` and `"auto"` schemes, and adjusted default text colors for existing schemes.
- Added CSS custom properties and a `prefers-color-scheme: light` media rule in `src/cfgtools/css.py` so the generated HTML can adapt styles using variables for foreground and add/delete backgrounds.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def197c6ac832a95e6dbed382142ad)