### PR TITLE
Fix light theme detection in VS Code webviews

### DIFF
--- a/src/cfgtools/css.py
+++ b/src/cfgtools/css.py
@@ -21,6 +21,14 @@ TREE_CSS_STYLE = """<style type="text/css">
         --cfgtools-change-add-bg: #d9f2d9;
     }}
 }}
+/* VS Code webviews do not always evaluate prefers-color-scheme correctly. */
+.vscode-light .{0},
+body[data-vscode-theme-kind="vscode-light"] .{0},
+body[data-vscode-theme-kind="vscode-high-contrast-light"] .{0} {{
+    --cfgtools-change-fg: #1f2328;
+    --cfgtools-change-del-bg: #ffd8d3;
+    --cfgtools-change-add-bg: #d9f2d9;
+}}
 .{0} li.m {{
     display: block;
     position: relative;


### PR DESCRIPTION
### Motivation
- VS Code webviews do not always honor `@media (prefers-color-scheme: light)`, which can cause the tree change colors to use the dark palette even when the editor is using a light theme.

### Description
- Add explicit VS Code light-theme selectors (`.vscode-light`, `body[data-vscode-theme-kind="vscode-light"]`, and `body[data-vscode-theme-kind="vscode-high-contrast-light"]`) to `TREE_CSS_STYLE` so the light palette CSS variables are applied in webviews while preserving the existing `@media` rule.

### Testing
- `python -m compileall -q src` succeeded.
- `pytest -q` was executed but discovered no tests (no tests ran).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69defd503f3c832ab90a516e1607d8ea)