### PR TITLE
fix: disable automatic system/VS Code theme detection for auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cfgtools.config({
 ```
 If user wants to check the changed items, run:
 ```py
->>> f.view_change()         # follow system theme (light/dark)
+>>> f.view_change()         # auto mode now uses light style
 >>> f.view_change("light")  # optimized for light/white backgrounds
 >>> f.view_change("dark")   # optimized for dark/black backgrounds
 ```

--- a/src/cfgtools/basic.py
+++ b/src/cfgtools/basic.py
@@ -112,11 +112,7 @@ def get_bg_colors(color_scheme: "ColorScheme") -> tuple[str, str, str]:
         case "light":
             return ["#1f2328", "#ffd8d3", "#d9f2d9"]
         case "auto":
-            return [
-                "var(--cfgtools-change-fg,#cccccc)",
-                "var(--cfgtools-change-del-bg,#4d2f2f)",
-                "var(--cfgtools-change-add-bg,#2f4d2f)",
-            ]
+            return ["#1f2328", "#ffd8d3", "#d9f2d9"]
         case _:
             raise ValueError(f"invalid color scheme: {color_scheme!r}")
 

--- a/src/cfgtools/css.py
+++ b/src/cfgtools/css.py
@@ -10,21 +10,6 @@ __all__ = []
 
 TREE_CSS_STYLE = """<style type="text/css">
 .{0} {{
-    --cfgtools-change-fg: #cccccc;
-    --cfgtools-change-del-bg: #4d2f2f;
-    --cfgtools-change-add-bg: #2f4d2f;
-}}
-@media (prefers-color-scheme: light) {{
-    .{0} {{
-        --cfgtools-change-fg: #1f2328;
-        --cfgtools-change-del-bg: #ffd8d3;
-        --cfgtools-change-add-bg: #d9f2d9;
-    }}
-}}
-/* VS Code webviews do not always evaluate prefers-color-scheme correctly. */
-.vscode-light .{0},
-body[data-vscode-theme-kind="vscode-light"] .{0},
-body[data-vscode-theme-kind="vscode-high-contrast-light"] .{0} {{
     --cfgtools-change-fg: #1f2328;
     --cfgtools-change-del-bg: #ffd8d3;
     --cfgtools-change-add-bg: #d9f2d9;


### PR DESCRIPTION
### Motivation
- Remove automatic detection of the host/system or VS Code webview theme so `auto` mode no longer switches based on environment and instead uses a fixed light palette.
- Simplify the HTML/CSS output to avoid relying on `prefers-color-scheme` and VS Code-specific DOM classes which produced inconsistent results in some viewers.

### Description
- Make `get_bg_colors("auto")` return the same color triplet as `light` in `src/cfgtools/basic.py` so `auto` resolves to a fixed light style.
- Remove `@media (prefers-color-scheme: light)` rules and VS Code webview overrides from `src/cfgtools/css.py`, leaving the light color variables as the default in the generated CSS.
- Update the README example comment to clarify that `view_change()` in auto mode now uses the light style in `README.md`.
- Modified files: `src/cfgtools/basic.py`, `src/cfgtools/css.py`, and `README.md`.

### Testing
- Ran `python -m compileall src` to verify modules compile successfully and the byte-compiled files were produced, and the command completed without errors.
- No automated unit tests were added or modified as part of this change and no test failures were observed during compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69defe81738c832aacecd62cd4489a94)